### PR TITLE
Fixed debug function in Cygwin on Windows 10

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -139,7 +139,7 @@ help() {
 }
 
 debug() {
-	[ -n "$VCSH_DEBUG" ] && echo "$SELF: debug: $@"
+	if [ -n "$VCSH_DEBUG" ]; then echo "$SELF: debug: $@"; fi
 }
 
 verbose() {


### PR DESCRIPTION
The debug function was causing a bad exit code when calling vcsh from mr on Windows 10.